### PR TITLE
Automatic architecture detection for building server

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-server-win-arm64": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer-arm64.exe -t node20-win-arm64",
     "build-server-linux-arm64": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer-arm64 -t node20-linux-arm64",
     "build-media": "node scripts/zip-media",
-    "build-win": "yarn build-server-win&&yarn build-client-win&&node scripts/zip-win"
+    "build-win": "yarn build-server-win-x64&&yarn build-client-win&&node scripts/zip-win"
   },
   "author": "CPS",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "build-mac": "yarn build-tsc && electron-builder build --mac --publish never",
     "build-linux": "yarn build-tsc && electron-builder build --linux --x64 --publish never",
     "dev": "nodemon src/server/main.ts",
-    "build-server-win": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer.exe -t node20-win",
-    "build-server-linux": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer -t node20-linux",
+    "build-server-win-x64": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer.exe -t node20-win-x64",
+    "build-server-linux-x64": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer -t node20-linux-x64",
+    "build-server-win-arm64": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer-arm64.exe -t node20-win-arm64",
+    "build-server-linux-arm64": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer-arm64 -t node20-linux-arm64",
     "build-media": "node scripts/zip-media",
     "build-win": "yarn build-server-win&&yarn build-client-win&&node scripts/zip-win"
   },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "build-mac": "yarn build-tsc && electron-builder build --mac --publish never",
     "build-linux": "yarn build-tsc && electron-builder build --linux --x64 --publish never",
     "dev": "nodemon src/server/main.ts",
-    "build-server-win": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer.exe -t node20-win-x64",
-    "build-server-linux": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer -t node20-linux-x64",
+    "build-server-win": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer.exe -t node20-win",
+    "build-server-linux": "tsc&&pkg compiled/server/main.js -o dist/WaddleForeverServer -t node20-linux",
     "build-media": "node scripts/zip-media",
     "build-win": "yarn build-server-win&&yarn build-client-win&&node scripts/zip-win"
   },


### PR DESCRIPTION
This lets it server be built on arm64 systems. I've tested it on arm64 and x64 linux, which both produce working windows/linux binaries. Hasn't been tested on Windows, but unless it can't detect its own architecture it should work fine.