### PR TITLE
Add "Explorer" and "Construction" stamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.vcxproj.filters
 *.vcxproj.user
 *.xcodeproj
+/pcode/
 /.idea/
 /dist/
 /compiled/

--- a/media/default/approximation/waterhunt_worldachievements.xml
+++ b/media/default/approximation/waterhunt_worldachievements.xml
@@ -26,7 +26,7 @@
 		<condition>user wearing only 195 or 10195</condition> 
 		<result>stampEarned 11</result> 
 	</achievement> 
-	
+ 
     <!-- ~~~ 12 - Go Swimming ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ --> 
 	<!-- This achievement is divided up for the different rooms it can be achieved from:  --> 
 	<achievement name="Go Swimming" id="12.0"> 
@@ -102,8 +102,8 @@
  
     <!-- ~~~ 14 - 183 days! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ --> 
 	
-	<!-- <achievement name="183 days!" id="14">  -->
-		<!-- <event>user enterRoom</event>  -->
+	<!-- <achievement name="183 days!" id="14"> 
+		<event>user enterRoom</event>  -->
 		<!-- player object meets the age requirement:                                     --> 
 		<!-- <condition>user hasProperty created_date greaterThan 182</condition> 
 		<result>stampEarned 14</result> 
@@ -173,8 +173,8 @@
 		<!-- player object meets the age requirement:                                     --> 
 		<!-- <condition>user hasProperty created_date greaterThan 364</condition> 
 		<result>stampEarned 20</result> 
-	</achievement> 
-     -->
+	</achievement>  -->
+    
     <!-- ~~~ 21 - Puffle Owner ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ --> 
 	
 	<achievement name="Puffle Owner" id="21"> 
@@ -428,48 +428,36 @@
         <result>stampEarned 182</result> 
     </achievement> 
  
-    <!-- ~~~ 184 - Tend a concession stand / Snack Shack ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ --> 
-	
-	<achievement name="Tend A Concession Stand" id="184"> 
-		<!-- This stamp expires on Wed, 01 Feb 2012 23:00:00 GMT     --> 
-        <!-- <expiryDate>1328137200</expiryDate> --> 
-		
-		<event>user sendEmote</event> 
-		<condition>user in 200 or 800</condition> 
-        <condition>user hits snackShack_mc or shipfront_mc</condition> 
-		<condition>event hasEmoteID 13 or 24 or 28 or 29 or 26 or 27</condition> 
-		<result>stampEarned 184</result> 
-	</achievement> 
- 
+
    	<!-- ~~~ 189 - Construction ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ --> 
     
-    <!-- <achievement name="Construction" id="189"> -->
+    <achievement name="Construction" id="189">
         <!-- This stamp expires on Wed, 23 Nov 2011 23:00:00 GMT     --> 
         <!-- <expiryDate>1322089200</expiryDate>  --> 
         
 		<!-- Break this condition down into a periodic check to reduce the chance of      --> 
 		<!-- affecting frame rate                                                         --> 
-		<!-- <event>every 2 seconds</event> 
-		<condition>user in 400</condition> 
+		<event>every 2 seconds</event> 
+		<condition>user in 816</condition> 
         <condition>user wearing only 342 or 5069 or 403 or 10403 or 429 or 10429 or 674 or 1133 or 11133</condition> 
         <condition>user isOnFrame 26</condition> 
         <result>stampEarned 189</result> 
-	</achievement> -->
+	</achievement>
  
     <!-- ~~~ 190 - Explorer ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
         
-    <!-- <achievement name="Explorer" id="190"> -->
+    <achievement name="Explorer" id="190">
         <!-- This stamp expires on Wed, 01 Feb 2012 23:00:00 GMT     --> 
         <!-- <expiryDate>1328137200</expiryDate>  --> 
         
 		<!-- Break this condition down into a periodic check to reduce the chance of      --> 
 		<!-- affecting frame rate                                                         --> 
-		<!-- <event>every 2 seconds</event> 
+		<event>every 2 seconds</event> 
         <condition>user hasProperty is_member equals 1</condition> 
-		<condition>user in 200 400 410 800 810 851 852 853 854 855 856 857</condition> 
+		<condition>user in 100 300 321 322 800 801 804 806 808 809 813 814 816</condition> 
         <result>stampEarned 190</result> 
-	</achievement>  -->
-	
+	</achievement>
+
 	<!-- ~~~ 332 - Food Fight ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ --> 
 	
 	<!-- <achievement name="Food Fight" id="332">

--- a/src/server/game-data/files.ts
+++ b/src/server/game-data/files.ts
@@ -200,6 +200,10 @@ would need to investigated`
       comment: 'Added Snack Shack stamp, by Supermanover'
     },
     {
+      file: 'waterhunt_worldachievements.xml',
+      comment: 'Added Explorer stamp, by Farizaku'
+    },
+    {
       file: 'forts_release.swf',
       comment: 'Removed ability to go to the Plaza, to simulate how the Snow Forts was during its release',
       base: 'archives:ArtworkRoomsForts12.swf'

--- a/src/server/game-data/parties.ts
+++ b/src/server/game-data/parties.ts
@@ -3040,6 +3040,9 @@ export const PARTIES: TemporaryUpdateTimeline<Party, PartyChanges> = [
     globalChanges: {
       'scavenger_hunt/hunt_ui.swf': ['archives:Sensei_Water_Scavenger_Hunt_closeup.swf', 'easter_egg_hunt', 'scavenger_hunt']
     },
+    generalChanges: {
+      'web_service/worldachievements.xml': 'approximation:waterhunt_worldachievements.xml'
+    },
     updates: [
       {
         date: Update.PLANET_Y_2010,

--- a/src/server/routes/stampjson.ts
+++ b/src/server/routes/stampjson.ts
@@ -1806,7 +1806,7 @@ export function getStampbook(version: Version): string {
     ])
   }
 
-  if (isGreaterOrEqual(version, '2010-11-24')) {
+  if (isGreaterOrEqual(version, '2010-11-16')){
     addStamps(newStampbook[CategoryID.Party] as Category, [
       {
         "stamp_id": 189,
@@ -1824,7 +1824,10 @@ export function getStampbook(version: Version): string {
         "description": "Visit all the decorated party rooms",
         "rank_token": "easy"
       }
-    ])
+    ])    
+  }
+  
+  if (isGreaterOrEqual(version, '2010-11-24')) {
 
     addStamps(newStampbook[CategoryID.Characters] as Category, [
       {


### PR DESCRIPTION
- Added explorer and constructor stamp to water scavenge hunt
- Documented waterhunt_worldachievments.xml to files.ts
- Made both stamps available on stampbook from Water Hunt (previously only in Celebration of Water)
- Aliased worldachievments.xml request during Water Hunt on parties.ts