### PR TITLE
Crumb building support added for Linux/MacOS and FFDEC version updated to v23-v24.1

### DIFF
--- a/crumbs/global-crumbs.ts
+++ b/crumbs/global-crumbs.ts
@@ -108,7 +108,7 @@ function addGlobalPath(crumbs: string, pathName: string, path: string): string {
  * @param crumbsContent The P-Code code content of the file
  */
 async function createCrumbs(outputPath: string, crumbsContent: string): Promise<void> {
-  await replacePcode(BASE_GLOBAL_CRUMBS, outputPath, '\\frame 1\\DoAction', crumbsContent);
+  await replacePcode(BASE_GLOBAL_CRUMBS, outputPath, path.join('/frame_1', 'DoAction'), crumbsContent);
 }
 
 function applyChanges(crumbs: string, changes: Partial<GlobalCrumbContent>): string {

--- a/crumbs/local-crumbs.ts
+++ b/crumbs/local-crumbs.ts
@@ -42,7 +42,7 @@ function applyChanges(crumbs: string, changes: Partial<LocalCrumbContent>): stri
 }
 
 async function createCrumbs(outputPath: string, crumbsContent: string): Promise<void> {
-  await replacePcode(BASE_LOCAL_CRUMBS, outputPath, '\\frame 1\\DoAction', crumbsContent);
+  await replacePcode(BASE_LOCAL_CRUMBS, outputPath, path.join('/frame_1', 'DoAction'), crumbsContent);
 }
 
 export async function generateLocalCrumbs() {

--- a/crumbs/news-crumbs.ts
+++ b/crumbs/news-crumbs.ts
@@ -178,7 +178,7 @@ async function processNewspaper(newspaper: LabeledAs2Newspaper | LabeledAs3Newsp
       const filePath = path.join(autoDir, fileName);
       console.log(`Exporting: ${fileName}`);
       
-      const promise = replacePcode(BASE_NEWS_CRUMBS, filePath, '\\frame 1\\DoAction', filecontent);
+      const promise = replacePcode(BASE_NEWS_CRUMBS, filePath, path.join('/frame_1', 'DoAction'), filecontent);
       promises.push(promise);
     }
   }

--- a/src/common/ffdec/ffdec.ts
+++ b/src/common/ffdec/ffdec.ts
@@ -32,7 +32,9 @@ export const replacePcode = async (baseFilePath: string, outputFilePath: string,
   
   await runCommand(`"${getFfdecPath()}" -replace "${baseFilePath}" "${outputFilePath}" "${scriptName}" "${tempfile}"`);
 
-  fs.unlinkSync(tempfile);
+  if(fs.existsSync(tempfile)) {
+    fs.unlinkSync(tempfile);
+  }
 }
 
 /**


### PR DESCRIPTION
Uses OS-dependent paths to add support for Linux and Mac, but would not work with older versions of FFDEC without a way to determine the version or set it as an environment variable.