### PR TITLE
Add websocket connectivity for Ruffle

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/express": "^5.0.0",
     "@types/node": "^18.13.0",
     "@types/unzipper": "^0.10.10",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
     "@yao-pkg/pkg": "^5.15.0",
@@ -114,6 +115,7 @@
     "electron-store": "^8.1.0",
     "electron-updater": "^5.3.0",
     "express": "^4.21.0",
-    "unzipper": "^0.12.3"
+    "unzipper": "^0.12.3",
+    "ws": "^8.19.0"
   }
 }

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -837,8 +837,13 @@ function capitalizeName(name: string): string {
   })).join(' ');
 }
 
+export interface ClientSocket {
+  write: (data: string) => Promise<void>;
+  end: (data?: string) => void;
+}
+
 export class Client {
-  private _socket: net.Socket | undefined;
+  private _socket: ClientSocket | undefined;
   /** Reference to the server */
   private _server: Server;
   protected _penguin: Penguin | undefined;
@@ -887,7 +892,7 @@ export class Client {
 
   private _pendingAgent: boolean = false;
 
-  constructor (server: Server, socket: net.Socket | undefined, type: ServerType) {
+  constructor (server: Server, socket: ClientSocket | undefined, type: ServerType) {
     this._server = server;
     this._socket = socket;
     this.serverType = type;
@@ -919,7 +924,7 @@ export class Client {
     return this._penguin ?? (() => { throw new Error('Getting penguin before initializing'); })();
   }
 
-  get socket(): net.Socket {
+  get socket(): ClientSocket {
     return this._socket ?? (() => { throw new Error('Getting socket before initializing'); })();
   }
 
@@ -928,14 +933,7 @@ export class Client {
   }
 
   async send (message: string): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      this._socket?.write(message + '\0', (err) => {
-        if (err !== undefined) {
-          reject(err);
-        }
-        resolve();
-      });
-    });
+    return this.socket?.write(message)
   }
 
   private getXtMessage(emptyLast: boolean, handler: string, ...args: Array<number | string>): string {

--- a/src/server/routes/game.ts
+++ b/src/server/routes/game.ts
@@ -142,15 +142,14 @@ export function createHttpServer(settingsManager: SettingsManager): HttpServer {
 
   server.addFileServer();
 
-  server.router.get('/', (req, res) => {
-    const page = getWebsiteName(settingsManager);
-
-    res.send(injectRuffleIntoHtml(settingsManager, page));
+  server.getData('/', (s) => {
+    const page = getWebsiteName(s);
+    return injectRuffleIntoHtml(s, page);
   })
 
   // Engine 3 login page requires this URL
-  server.router.get('/#/login', (req, res) => {
-    res.send(injectRuffleIntoHtml(settingsManager, 'default/websites/modern-as3.html'));
+  server.getData('/#/login', (s) => {
+    return injectRuffleIntoHtml(s, 'default/websites/modern-as3.html');
   })
 
   // serving the websites

--- a/src/server/routes/game.ts
+++ b/src/server/routes/game.ts
@@ -93,31 +93,64 @@ function replaceConstants(file: FileRef, constantValues: Record<string, string |
   return Buffer.from(emitSwf(swf));
 }
 
+function getWebsiteName(s: SettingsManager) {
+  const name = findInVersion(s.settings.version, INDEX_HTML_TIMELINE);
+
+  if (s.settings.minified_website && name !== 'modern-as3') {
+    if (isAS3(s.settings.version)) {
+      return 'default/websites/minified/minified-classic-as3.html';
+    } else if (isPreCpip(s.settings.version)) {
+      return 'default/websites/minified/minified-precpip.html';
+    } else {
+      return 'default/websites/minified/minified-cpip.html';
+    }
+  }
+
+  return `default/websites/${name}.html`;
+}
+
+function injectRuffleIntoHtml(s: SettingsManager, page: string) {
+  const ruffleConfig = JSON.stringify({
+    socketProxy: [
+      {
+        host: s.targetIP,
+        port: s.loginPort,
+        proxyUrl: `ws://${s.targetIP}:${s.loginPort}`,
+      },
+      {
+        host: s.targetIP,
+        port: s.worldPort,
+        proxyUrl: `ws://${s.targetIP}:${s.worldPort}`,
+      },
+    ]
+  });
+
+  const html = fs.readFileSync(path.join(MEDIA_DIRECTORY, page), 'utf8');
+
+  const injectedScript = `
+    <script>
+      window.RufflePlayer = window.RufflePlayer || {};
+      window.RufflePlayer.config = ${ruffleConfig};
+    </script>
+  `;
+
+  return html.replace('</head>', `${injectedScript}</head>`);
+}
+
 export function createHttpServer(settingsManager: SettingsManager): HttpServer {
   const server = new HttpServer(settingsManager);
 
   server.addFileServer();
 
-  server.get('/', (s) => {
-    const name = findInVersion(s.settings.version, INDEX_HTML_TIMELINE);
+  server.router.get('/', (req, res) => {
+    const page = getWebsiteName(settingsManager);
 
-    if (s.settings.minified_website && name !== 'modern-as3') {
-      if (isAS3(s.settings.version)) {
-        return 'default/websites/minified/minified-classic-as3.html';
-      } else if (isPreCpip(s.settings.version)) {
-        return 'default/websites/minified/minified-precpip.html';
-      } else {
-        return 'default/websites/minified/minified-cpip.html';
-      }
-    }
-
-    return `default/websites/${name}.html`;
-  });
-
+    res.send(injectRuffleIntoHtml(settingsManager, page));
+  })
 
   // Engine 3 login page requires this URL
-  server.get('/#/login', () => {
-    return `default/websites/modern-as3.html`;
+  server.router.get('/#/login', (req, res) => {
+    res.send(injectRuffleIntoHtml(settingsManager, 'default/websites/modern-as3.html'));
   })
 
   // serving the websites

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,11 +1,12 @@
 import express, { Express } from 'express';
 import net from 'net';
+import { WebSocketServer } from 'ws'
 
 import { Handler } from './handlers';
 import { LOGIN_PORT, WORLD_PORT } from './servers';
 import worldHandler from './handlers/world'
 import loginHandler from './handlers/login'
-import { Client, Server } from './client';
+import { Client, Server, ClientSocket } from './client';
 import { SettingsManager } from './settings';
 import { createHttpServer } from './routes/game';
 import db from './database';
@@ -20,31 +21,111 @@ const createServer = async (type: string, port: number, handler: Handler, settin
 
   handler.bootServer(gameServer);
 
-  await new Promise<void>((resolve, reject) => {
-    net.createServer((socket) => {
-      socket.setEncoding('utf8');
-  
-      console.log(`A client has connected to ${type}`);
+  function makeClient(cs: ClientSocket) {
+    return new Client(
+      gameServer,
+      cs,
+      type === 'Login' ? 'Login' : 'World'
+    );
+  }
 
-      const client = new Client(
-        gameServer,
-        socket,
-        type === 'Login' ? 'Login' : 'World'
-      );
-      socket.on('data', (data: Buffer) => {
-        const dataStr = data.toString().split('\0')[0];
-        handler.handle(client, dataStr);
+  await new Promise<void>((resolve, reject) => {
+    const wsServer = new WebSocketServer({ noServer: true });
+    
+    wsServer.on('connection', (ws, req) => {
+      console.log(`A client has connected to ${type} (WebSocket)`);
+
+      const cs: ClientSocket = {
+        write: async (message: string) => {
+          return new Promise<void>((resolve, reject) => {
+            ws.send(Buffer.from(message + '\0', 'utf8'), { binary: true }, (err) => {
+              if (err !== undefined) {
+                reject(err);
+              }
+              resolve();
+            });
+          })
+        },
+
+        end: (d) => ws.close(undefined, d)
+      }
+
+      const client = makeClient(cs)
+
+      ws.on('message', (data) => {
+        handler.handle(client, data.toString());
       });
-  
-      socket.on('close', () => {
+
+      ws.on('close', () => {
         for (const method of handler.disconnectListeners) {
           method(client);
         }
-        console.log('A client has disconnected');
+        console.log('A client has disconnected (WebSocket)');
       });
+
+      ws.emit('message', req)
+
+      ws.on('error', console.error)
+    });
+
+    function parseHeaders(data: string) {
+      const lines = data.split('\r\n');
+      const headers: Record<string, string> = {};
+      for (let i = 1; i < lines.length; i++) {
+        const [key, value] = lines[i].split(': ');
+        if (key && value) {
+          headers[key.toLowerCase()] = value;
+        }
+      }
+      return headers;
+    }
   
-      socket.on('error', (error) => {
-        console.error(error);
+    net.createServer((socket) => {
+      socket.once('data', (buffer) => {
+        const dataStr = buffer.toString()
+
+        if (dataStr.startsWith('GET')) {
+          // This is a websocket connection
+          wsServer.handleUpgrade({ headers: parseHeaders(dataStr), method: 'GET' } as any, socket, buffer, (ws) => {
+            wsServer.emit('connection', ws, dataStr);
+          });
+        } else {
+          socket.setEncoding('utf8')
+          console.log(`A client has connected to ${type}`);
+
+          const cs: ClientSocket = {
+            write: async (message: string) => {
+              return new Promise<void>((resolve, reject) => {
+                socket.write(message + '\0', (err) => {
+                  if (err !== undefined) {
+                    reject(err);
+                  }
+                  resolve();
+                });
+              })
+            },
+            end: (d: any) => socket.end(d)
+          }
+
+          const client = makeClient(cs)
+
+          socket.on('data', (data: Buffer) => {
+            const dataStr = data.toString().split('\0')[0];
+            handler.handle(client, dataStr);
+          });
+
+          socket.on('close', () => {
+            for (const method of handler.disconnectListeners) {
+              method(client);
+            }
+            console.log('A client has disconnected');
+          });
+
+          // Re-emit the data so the TCP handler gets the first packet too
+          socket.emit('data', buffer);
+
+          socket.on('error', console.error)
+        }
       });
     }).listen(port, () => {
       console.log(`${type} server listening on port ${port}`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -104,7 +104,13 @@ const createServer = async (type: string, port: number, handler: Handler, settin
                 });
               })
             },
-            end: (d: any) => socket.end(d)
+            end: (d) => {
+              if (d === undefined) {
+                socket.end();
+              } else {
+                socket.end(d);
+              }
+            }
           }
 
           const client = makeClient(cs)

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,6 +491,13 @@
   resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.6.tgz#3e600c62d210c5826460858f84bcbb65805460bb"
   integrity sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==
 
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -4453,6 +4460,11 @@ ws@^7.3.1:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^8.19.0:
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
+  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Allows the game (in all points of the timeline) to run in a browser with Ruffle.

A WebSocket server is spun up, and when the net server receives a connection, if the data starts with "GET", then the socket is turned into a WebSocket connection.

Also reworked how the main website is served, to allow for Ruffle's config for the socket proxy to be dynamically injected.

Adds a new package (`ws`).