### PR TITLE
🚀 Update: Party Log test in the timeline

### DIFF
--- a/src/client/static/timeline-static.ts
+++ b/src/client/static/timeline-static.ts
@@ -1,4 +1,4 @@
-import { getSettings, post } from "./common-static.js";
+import { getJson, getSettings, post } from "./common-static.js";
 
 const timelineApi = (window as any).api;
 
@@ -71,6 +71,700 @@ type DateInfo = {
   selected?: boolean;
   inParty: boolean;
 };
+
+type PartyInfo = {
+  id: string;
+  title: string;
+  startDate: string;
+  endDate?: string;
+  startDay: DateInfo;
+};
+
+function getPartyId(title: string, startDate: string): string {
+  return `${title.toLowerCase()}::${startDate}`;
+}
+
+function stripHtml(html: string): string {
+  const parser = new DOMParser();
+  return parser.parseFromString(html, 'text/html').body.textContent?.trim() ?? html;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizePartyTitle(text: string): string {
+  const plainText = stripHtml(text)
+    .replace(/\s+/g, ' ')
+    .replace(/\b(starts?|begins?|ends?)\b/gi, '')
+    .replace(/\s+-\s+/g, ' ')
+    .trim();
+
+  return plainText.length > 0 ? plainText : 'Unnamed Party';
+}
+
+function buildPartyIndex(days: DateInfo[]): PartyInfo[] {
+  const sortedDays = [...days].sort((a, b) => {
+    return getDateFromDateInfo(a).getTime() - getDateFromDateInfo(b).getTime();
+  });
+  const activeParties: Record<string, PartyInfo[]> = {};
+  const parties: PartyInfo[] = [];
+
+  for (const day of sortedDays) {
+    const date = getDateFormat(day);
+
+    day.events.forEach((event) => {
+      if (event.party === undefined) {
+        return;
+      }
+
+      const partyTitle = normalizePartyTitle(event.text);
+      const key = partyTitle.toLowerCase();
+
+      if (event.party === 'start') {
+        const partyInfo: PartyInfo = {
+          id: getPartyId(partyTitle, date),
+          title: partyTitle,
+          startDate: date,
+          startDay: day,
+        };
+
+        if (activeParties[key] === undefined) {
+          activeParties[key] = [];
+        }
+        activeParties[key].push(partyInfo);
+        parties.push(partyInfo);
+      }
+
+      if (event.party === 'end') {
+        const activeList = activeParties[key];
+        const partyToClose = activeList?.shift();
+        if (partyToClose !== undefined) {
+          partyToClose.endDate = date;
+        }
+      }
+    });
+  }
+
+  return parties.sort((a, b) => {
+    return new Date(b.startDate).getTime() - new Date(a.startDate).getTime();
+  });
+}
+
+function getPartyDisplayName(party: PartyInfo): string {
+  const startInfo = getDateInfo(party.startDate);
+  return `${party.title} (${startInfo.year})`;
+}
+
+function getPartySubtitle(party: PartyInfo): string {
+  const startInfo = getDateInfo(party.startDate);
+  const startText = getFullDate(startInfo, true);
+  if (party.endDate === undefined) {
+    return `Started on ${startText}`;
+  }
+
+  const endInfo = getDateInfo(party.endDate);
+  return `${startText} → ${getFullDate(endInfo, true)}`;
+}
+
+function getPartySearchScore(query: string, party: PartyInfo): number {
+  const normalizedQuery = query.toLowerCase();
+  const title = party.title.toLowerCase();
+  const subtitle = getPartySubtitle(party).toLowerCase();
+
+  if (title === normalizedQuery) {
+    return 100;
+  }
+  if (title.startsWith(normalizedQuery)) {
+    return 80;
+  }
+  if (title.includes(normalizedQuery)) {
+    return 60;
+  }
+  if (subtitle.includes(normalizedQuery)) {
+    return 40;
+  }
+
+  return 0;
+}
+
+function setupBitacora(days: DateInfo[]) {
+  const partyFavorites = new Set<string>();
+  const partyIndex = buildPartyIndex(days);
+
+  const DAY_COMMENT_STORAGE_KEY = 'timeline-bitacora-comments';
+  const PARTY_COMMENT_STORAGE_KEY = 'timeline-bitacora-party-comments';
+  const LAST_PENGUIN_STORAGE_KEY = 'timeline-bitacora-last-penguin';
+
+  type ActivePenguin = { id: number; name: string; };
+
+  const dayComments: Record<string, string> = {};
+  const partyComments: Record<string, string> = {};
+  let activePenguin: ActivePenguin | null = null;
+  let saveCommentsTimeout: NodeJS.Timeout | undefined;
+
+  const assignComments = (target: Record<string, string>, source: Record<string, string>) => {
+    Object.keys(target).forEach((key) => {
+      delete target[key];
+    });
+    Object.entries(source).forEach(([key, value]) => {
+      if (typeof value === 'string' && value.trim().length > 0) {
+        target[key] = value;
+      }
+    });
+  };
+
+  const readLastPenguinFromStorage = (): ActivePenguin | null => {
+    try {
+      const raw = localStorage.getItem(LAST_PENGUIN_STORAGE_KEY);
+      if (raw === null) {
+        return null;
+      }
+      const parsed = JSON.parse(raw) as { id?: unknown; name?: unknown; };
+      if (typeof parsed.id !== 'number' || !Number.isInteger(parsed.id) || parsed.id <= 0) {
+        return null;
+      }
+      if (typeof parsed.name !== 'string' || parsed.name.trim().length === 0) {
+        return null;
+      }
+      return { id: parsed.id, name: parsed.name };
+    } catch (_error) {
+      return null;
+    }
+  };
+
+  const persistLastPenguin = (penguin: ActivePenguin) => {
+    localStorage.setItem(LAST_PENGUIN_STORAGE_KEY, JSON.stringify(penguin));
+  };
+
+  const getActivePenguin = async (): Promise<ActivePenguin | null> => {
+    const players = await getJson('players') as Array<{ id: number; name: string; }>;
+    if (Array.isArray(players) && players.length > 0 && typeof players[0].id === 'number' && typeof players[0].name === 'string') {
+      activePenguin = { id: players[0].id, name: players[0].name };
+      persistLastPenguin(activePenguin);
+      return activePenguin;
+    }
+
+    if (activePenguin !== null) {
+      return activePenguin;
+    }
+
+    activePenguin = readLastPenguinFromStorage();
+    return activePenguin;
+  };
+
+  const queueCommentsSave = () => {
+    if (saveCommentsTimeout !== undefined) {
+      clearTimeout(saveCommentsTimeout);
+    }
+
+    saveCommentsTimeout = setTimeout(async () => {
+      try {
+        const currentPenguin = await getActivePenguin();
+        if (currentPenguin === null) {
+          return;
+        }
+
+        await post('timeline-comments/save', {
+          penguinId: currentPenguin.id,
+          dayComments,
+          partyComments,
+          favoriteParties: Array.from(partyFavorites.values())
+        });
+      } catch (_error) {
+        statusElement.innerText = 'Could not sync notes to data storage.';
+      }
+    }, 120);
+  };
+
+  const loadCommentsFromServer = async () => {
+    const currentPenguin = await getActivePenguin();
+    if (currentPenguin === null) {
+      updateActivePenguinUI();
+      updateCommentAvailability();
+      statusElement.innerText = 'Log in with a penguin to sync and save your notes.';
+      return;
+    }
+
+    const data = await getJson(`timeline-comments/get/${currentPenguin.id}`) as {
+      dayComments?: Record<string, string>;
+      partyComments?: Record<string, string>;
+      favoriteParties?: string[];
+    };
+
+    assignComments(dayComments, data.dayComments ?? {});
+    assignComments(partyComments, data.partyComments ?? {});
+    partyFavorites.clear();
+    (data.favoriteParties ?? []).forEach((partyId) => {
+      if (typeof partyId === 'string') {
+        partyFavorites.add(partyId);
+      }
+    });
+
+    updateActivePenguinUI();
+    updateCommentAvailability();
+    renderParties();
+    renderDetails();
+  };
+  const dayMap: Record<string, DateInfo> = {};
+  days.forEach((day) => {
+    dayMap[getDateFormat(day)] = day;
+  });
+
+  let selectedEntry: { date: string; title: string; description: string; detailsHtml: string; } | null = null;
+  let selectedParty: PartyInfo | null = null;
+  let usePartyComment = false;
+  const partyById: Record<string, PartyInfo> = {};
+  partyIndex.forEach((party) => {
+    partyById[party.id] = party;
+  });
+
+  timelineElement.innerHTML = `
+  <div class="bitacora-layout">
+    <div class="bitacora-card">
+      <div class="bitacora-title">📚 Party Logbook</div>
+      <div class="bitacora-input-row">
+        <input id="bitacora-party-search" class="party-search" type="search" placeholder="Search for a party (Music Jam, Halloween, Holiday...)" />
+        <label class="favorites-filter" for="bitacora-favorites-only">
+          <input id="bitacora-favorites-only" type="checkbox" />
+          <span>❤️ Favorites only</span>
+        </label>
+      </div>
+      <div class="bitacora-title">🎉 Parties</div>
+      <div id="bitacora-party-results" class="bitacora-results"></div>
+    </div>
+    <div class="bitacora-card">
+      <div class="bitacora-details-head-row">
+        <div id="bitacora-details-head" class="bitacora-details-head">Select a party to open your logbook ✍️</div>
+        <div class="bitacora-details-meta">
+          <div id="bitacora-active-penguin" class="bitacora-active-penguin">🐧 Logbook owner: none</div>
+          <button id="bitacora-mode-party" class="bitacora-mode-button" title="Toggle party-wide note mode">🎉 Party note</button>
+        </div>
+      </div>
+      <div id="bitacora-details-body"></div>
+      <textarea id="bitacora-comment-box" class="bitacora-comment-box" placeholder="Write a note for this specific day..."></textarea>
+      <div id="bitacora-status" class="bitacora-status">Auto-save enabled. Your notes are saved instantly.</div>
+    </div>
+  </div>
+  `;
+
+  window.scrollTo({ top: 0, behavior: 'auto' });
+
+  const as3Footer = document.getElementById('as3-footer');
+  if (as3Footer !== null) {
+    as3Footer.innerHTML = '';
+  }
+
+  activePenguin = readLastPenguinFromStorage();
+
+  const partySearchElement = document.getElementById('bitacora-party-search') as HTMLInputElement;
+  const favoriteOnlyToggleElement = document.getElementById('bitacora-favorites-only') as HTMLInputElement;
+  const partyResultsElement = document.getElementById('bitacora-party-results') as HTMLDivElement;
+  const commentBox = document.getElementById('bitacora-comment-box') as HTMLTextAreaElement;
+  const detailsHead = document.getElementById('bitacora-details-head') as HTMLDivElement;
+  const detailsBody = document.getElementById('bitacora-details-body') as HTMLDivElement;
+  const statusElement = document.getElementById('bitacora-status') as HTMLDivElement;
+  const partyModeButton = document.getElementById('bitacora-mode-party') as HTMLButtonElement;
+  const activePenguinElement = document.getElementById('bitacora-active-penguin') as HTMLDivElement;
+
+  const updateActivePenguinUI = () => {
+    if (activePenguin === null) {
+      activePenguinElement.innerText = '🐧 Logbook owner: none';
+    } else {
+      activePenguinElement.innerText = `🐧 Logbook owner: ${activePenguin.name}`;
+    }
+  };
+
+  const updateCommentAvailability = () => {
+    const canComment = activePenguin !== null;
+    commentBox.disabled = !canComment;
+    if (!canComment) {
+      commentBox.value = '';
+      commentBox.placeholder = 'Log in (or use last penguin) to write notes.';
+    }
+  };
+
+  const updateModeButtonState = () => {
+    const partyHasComment = selectedParty !== null && hasCommentValue(partyComments[selectedParty.id]);
+    const commentBadge = partyHasComment
+      ? '<span class="bitacora-button-comment-badge" aria-label="Party note exists">💬</span>'
+      : '';
+    partyModeButton.innerHTML = `${commentBadge}<span>🎉 Party note</span>`;
+    partyModeButton.classList.toggle('active', usePartyComment);
+    partyModeButton.disabled = selectedParty === null || activePenguin === null;
+    partyModeButton.setAttribute('aria-pressed', usePartyComment ? 'true' : 'false');
+  };
+
+  const getCurrentCommentContext = (): { storageKey: string; key: string; label: string; } | null => {
+    if (selectedEntry === null) {
+      return null;
+    }
+
+    if (usePartyComment) {
+      if (selectedParty === null) {
+        return null;
+      }
+      return {
+        storageKey: PARTY_COMMENT_STORAGE_KEY,
+        key: selectedParty.id,
+        label: `party ${getPartyDisplayName(selectedParty)}`
+      };
+    }
+
+    return {
+      storageKey: DAY_COMMENT_STORAGE_KEY,
+      key: selectedEntry.date,
+      label: `day ${getFullDate(getDateInfo(selectedEntry.date), true)}`
+    };
+  };
+
+  const hasCommentValue = (value: string | undefined): boolean => {
+    return value !== undefined && value.trim().length > 0;
+  };
+
+  const readCurrentCommentValue = (): string => {
+    const context = getCurrentCommentContext();
+    if (context === null) {
+      return '';
+    }
+    if (context.storageKey === PARTY_COMMENT_STORAGE_KEY) {
+      return partyComments[context.key] ?? '';
+    }
+    return dayComments[context.key] ?? '';
+  };
+
+  const persistCurrentComment = () => {
+    if (activePenguin === null) {
+      statusElement.innerText = 'Log in with a penguin to save notes.';
+      return;
+    }
+
+    const context = getCurrentCommentContext();
+    if (context === null) {
+      return;
+    }
+
+    const value = commentBox.value;
+    if (context.storageKey === PARTY_COMMENT_STORAGE_KEY) {
+      if (value.trim().length === 0) {
+        delete partyComments[context.key];
+      } else {
+        partyComments[context.key] = value;
+      }
+      queueCommentsSave();
+    } else {
+      if (value.trim().length === 0) {
+        delete dayComments[context.key];
+      } else {
+        dayComments[context.key] = value;
+      }
+      queueCommentsSave();
+    }
+
+    statusElement.innerText = `Auto-saved ${context.label} note.`;
+  };
+
+
+  const updateSelectedDayCommentBadge = () => {
+    if (selectedEntry === null || usePartyComment) {
+      return;
+    }
+
+    const dayButton = detailsBody.querySelector(`[data-party-date="${selectedEntry.date}"]`);
+    if (!(dayButton instanceof HTMLButtonElement)) {
+      return;
+    }
+
+    const hasComment = hasCommentValue(dayComments[selectedEntry.date]);
+    dayButton.classList.toggle('mini-day-button-commented', hasComment);
+
+    const existingBadge = dayButton.querySelector('.mini-day-comment-badge');
+    if (hasComment && existingBadge === null) {
+      dayButton.insertAdjacentHTML('afterbegin', '<span class="mini-day-comment-badge" aria-label="Has note">💬</span>');
+    } else if (!hasComment && existingBadge !== null) {
+      existingBadge.remove();
+    }
+  };
+
+  const refreshCommentEditor = () => {
+    updateActivePenguinUI();
+    updateCommentAvailability();
+    updateModeButtonState();
+    commentBox.placeholder = usePartyComment
+      ? 'Write a global note for this party...'
+      : 'Write a note for this specific day...';
+    commentBox.value = readCurrentCommentValue();
+    if (activePenguin === null) {
+      statusElement.innerText = 'Log in with a penguin to save notes.';
+    } else {
+      statusElement.innerText = usePartyComment
+        ? 'Party note mode active (auto-save enabled).'
+        : 'Day note mode active (auto-save enabled).';
+    }
+  };
+
+  commentBox.addEventListener('input', () => {
+    persistCurrentComment();
+    updateSelectedDayCommentBadge();
+    updateModeButtonState();
+    renderParties();
+  });
+
+  const getPartyDates = (party: PartyInfo): string[] => {
+    const datesInRange: string[] = [];
+    const endDate = party.endDate ?? party.startDate;
+    const startParts = getDateInfo(party.startDate);
+    const endParts = getDateInfo(endDate);
+    const startDate = new Date(startParts.year, startParts.month - 1, startParts.day);
+    const finalDate = new Date(endParts.year, endParts.month - 1, endParts.day);
+
+    for (let date = new Date(startDate); date <= finalDate; date.setDate(date.getDate() + 1)) {
+      const dateStr = getDateFormat({
+        year: date.getFullYear(),
+        month: date.getMonth() + 1,
+        day: date.getDate()
+      });
+
+      // only keep days that are actually registered in timeline data
+      if (dayMap[dateStr] !== undefined) {
+        datesInRange.push(dateStr);
+      }
+    }
+
+    return datesInRange.length > 0 ? datesInRange : [party.startDate];
+  };
+
+  const partyHasAnyComment = (party: PartyInfo): boolean => {
+    if (hasCommentValue(partyComments[party.id])) {
+      return true;
+    }
+
+    const partyDates = getPartyDates(party);
+    return partyDates.some((date) => hasCommentValue(dayComments[date]));
+  };
+
+  const getDayDescriptionForBitacora = (date: string): string => {
+    const day = dayMap[date];
+    if (day === undefined) {
+      return '<div class="party-result-subtitle">This day is not registered in the timeline.</div>';
+    }
+    return getDescription(day);
+  };
+
+  const renderDetails = () => {
+    if (selectedEntry === null) {
+      detailsHead.innerText = 'Select a party to open your logbook ✍️';
+      detailsBody.innerHTML = '';
+      commentBox.value = '';
+      return;
+    }
+
+    detailsHead.innerText = selectedEntry.title;
+
+    const miniCalendarHtml = selectedParty === null ? '' : (() => {
+      const partyDates = getPartyDates(selectedParty);
+      const modeHint = usePartyComment
+        ? '<div class="bitacora-mini-calendar-mode">Party note mode is active. Select a day chip to switch back to day notes.</div>'
+        : '';
+      return `
+      <div class="bitacora-mini-calendar">
+        <div class="bitacora-mini-calendar-title">Select the exact day of the party:</div>
+        ${modeHint}
+        <div class="bitacora-mini-calendar-grid">
+          ${partyDates.map((date) => {
+            const parsedDate = getDateInfo(date);
+            const selectedClass = (!usePartyComment && selectedEntry?.date === date) ? 'selected-mini-day' : '';
+            const commentedClass = hasCommentValue(dayComments[date]) ? 'mini-day-button-commented' : '';
+            const commentBadge = hasCommentValue(dayComments[date])
+              ? '<span class="mini-day-comment-badge" aria-label="Has note">💬</span>'
+              : '';
+            return `<button class="mini-day-button ${selectedClass} ${commentedClass}" data-party-date="${date}">${commentBadge}<span>${parsedDate.day} ${MONTHS[parsedDate.month - 1].slice(0, 3)}</span></button>`;
+          }).join('')}
+        </div>
+      </div>`;
+    })();
+
+    detailsBody.innerHTML = `
+      <div class="party-result-subtitle bitacora-description">${escapeHtml(selectedEntry.description)}</div>
+      ${miniCalendarHtml}
+      ${selectedEntry.detailsHtml}
+    `;
+
+    detailsBody.querySelectorAll('[data-party-date]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        if (!(button instanceof HTMLElement)) {
+          return;
+        }
+        const date = button.dataset.partyDate;
+        if (date === undefined || selectedParty === null) {
+          return;
+        }
+
+        usePartyComment = false;
+        await openEntry(
+          date,
+          `🎉 ${getPartyDisplayName(selectedParty)}`,
+          `${getPartySubtitle(selectedParty)} · Selected day: ${getFullDate(getDateInfo(date), true)}`,
+          getDayDescriptionForBitacora(date),
+          selectedParty
+        );
+      });
+    });
+
+    refreshCommentEditor();
+  };
+
+  const openEntry = async (
+    date: string,
+    title: string,
+    description: string,
+    detailsHtml: string,
+    partyForCalendar: PartyInfo | null = null
+  ) => {
+    selectedEntry = { date, title, description, detailsHtml };
+    selectedParty = partyForCalendar;
+    usePartyComment = false;
+    const { month, year } = getDateInfo(date);
+    setSelectElements(month, year);
+    await updateVersion(date);
+    renderDetails();
+  };
+
+  const renderParties = () => {
+    const query = partySearchElement.value.trim();
+    const onlyFavorites = favoriteOnlyToggleElement.checked;
+
+    let filteredParties = partyIndex;
+    if (onlyFavorites) {
+      filteredParties = filteredParties.filter((party) => partyFavorites.has(party.id));
+    }
+
+    if (query.length > 0) {
+      filteredParties = filteredParties
+        .map((party) => ({ party, score: getPartySearchScore(query, party) }))
+        .filter(({ score }) => score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map(({ party }) => party);
+    } else {
+      // default sort: favorites first, then newest first (existing order)
+      filteredParties = [...filteredParties].sort((a, b) => {
+        return Number(partyFavorites.has(b.id)) - Number(partyFavorites.has(a.id));
+      });
+    }
+
+    const matches = filteredParties.slice(0, 15);
+
+    if (matches.length === 0) {
+      partyResultsElement.innerHTML = `<div class="party-result-item"><div class="party-result-content"><div class="party-result-title">No parties found</div><div class="party-result-subtitle">Try another keyword or disable the favorites filter.</div></div></div>`;
+      return;
+    }
+
+    partyResultsElement.innerHTML = matches.map((party) => {
+      const heart = partyFavorites.has(party.id) ? '❤️' : '♡';
+      const hasAnyNote = partyHasAnyComment(party);
+      const noteIndicator = hasAnyNote
+        ? '<span class="party-note-indicator" aria-label="This party has notes">💬</span>'
+        : '';
+      return `
+      <div class="party-result-item" data-party-id="${party.id}" data-date="${party.startDate}">
+        <div class="party-result-content">
+          <div class="party-result-title">${escapeHtml(getPartyDisplayName(party))}</div>
+          <div class="party-result-subtitle">${escapeHtml(getPartySubtitle(party))}</div>
+        </div>
+        <div class="party-result-actions">
+          ${noteIndicator}
+          <button class="favorite-heart-button" data-favorite-toggle="true" data-party-id="${party.id}">${heart}</button>
+        </div>
+      </div>`;
+    }).join('');
+
+  };
+
+  partyResultsElement.addEventListener('click', async (event) => {
+    if (!(event.target instanceof HTMLElement)) {
+      return;
+    }
+
+    const targetItem = event.target.closest('.party-result-item');
+    if (!(targetItem instanceof HTMLElement)) {
+      return;
+    }
+
+    const partyId = targetItem.dataset.partyId;
+    if (partyId === undefined) {
+      return;
+    }
+
+    if (event.target.dataset.favoriteToggle === 'true') {
+      event.stopPropagation();
+      if (activePenguin === null) {
+        statusElement.innerText = 'Log in with a penguin to manage favorite parties.';
+        return;
+      }
+
+      if (partyFavorites.has(partyId)) {
+        partyFavorites.delete(partyId);
+      } else {
+        partyFavorites.add(partyId);
+      }
+      queueCommentsSave();
+      renderParties();
+      return;
+    }
+
+    const party = partyById[partyId];
+    if (party === undefined) {
+      return;
+    }
+
+    await openEntry(
+      party.startDate,
+      `🎉 ${getPartyDisplayName(party)}`,
+      getPartySubtitle(party),
+      getDayDescriptionForBitacora(party.startDate),
+      party
+    );
+  });
+
+  partyModeButton.onclick = () => {
+    if (selectedParty === null) {
+      statusElement.innerText = 'Select a party first to use party-level notes.';
+      return;
+    }
+
+    usePartyComment = !usePartyComment;
+    statusElement.innerText = usePartyComment
+      ? 'Party note mode enabled. Select any day chip to switch back to day notes.'
+      : 'Day note mode enabled.';
+    renderDetails();
+  };
+
+  let partySearchDebounce: NodeJS.Timeout | undefined;
+  partySearchElement.oninput = () => {
+    if (partySearchDebounce !== undefined) {
+      clearTimeout(partySearchDebounce);
+    }
+    partySearchDebounce = setTimeout(() => {
+      renderParties();
+    }, 80);
+  };
+  favoriteOnlyToggleElement.onchange = renderParties;
+
+  updateModeButtonState();
+  renderParties();
+  renderDetails();
+  loadCommentsFromServer().catch(() => {
+    statusElement.innerText = 'Could not sync notes from data storage.';
+  });
+
+  yearElement.onchange = () => setupBitacora(days);
+  monthElement.onchange = () => setupBitacora(days);
+}
 
 function getDateInfo(dateStr: string) : {
   year: number;
@@ -569,6 +1263,7 @@ window.addEventListener('get-timeline', (e: any) => {
 
   const calendarButton = document.getElementById('calendar-timeline')! as HTMLInputElement;
   const listButton = document.getElementById('list-timeline')! as HTMLInputElement;
+  const bitacoraButton = document.getElementById('bitacora-timeline')! as HTMLInputElement;
 
   calendarButton.addEventListener('change', (e) => {
     if (e.target instanceof HTMLInputElement && e.target.checked) {
@@ -579,6 +1274,12 @@ window.addEventListener('get-timeline', (e: any) => {
   listButton.addEventListener('change', (e) => {
     if (e.target instanceof HTMLInputElement && e.target.checked) {
       updateTimeline(days);
+    }
+  });
+
+  bitacoraButton.addEventListener('change', (e) => {
+    if (e.target instanceof HTMLInputElement && e.target.checked) {
+      setupBitacora(days);
     }
   });
 });

--- a/src/client/views/timeline.css
+++ b/src/client/views/timeline.css
@@ -66,6 +66,7 @@
 .timeline-header {
   position: sticky;
   top: 0;
+  z-index: 20;
   background-color: var(--background-solid);
   box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.25);
   left: 0;
@@ -89,6 +90,284 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 0.3em;
+}
+
+
+.bitacora-layout {
+  display: grid;
+  grid-template-columns: minmax(20em, 30em) minmax(0, 1fr);
+  gap: 1em;
+  align-items: start;
+  min-height: calc(100vh - 10.5em);
+}
+
+.bitacora-card {
+  border: 1px solid #9cc9e5;
+  border-radius: 12px;
+  background: white;
+  color: #0b2a42;
+  padding: 1em;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  min-height: 0;
+}
+
+.bitacora-title {
+  font-size: 1.2em;
+  font-weight: 700;
+  margin-bottom: 0.6em;
+}
+
+.bitacora-input-row {
+  display: flex;
+  gap: 0.5em;
+  align-items: center;
+  margin-bottom: 0.7em;
+}
+
+.party-search {
+  width: 100%;
+  border-radius: 999px;
+  border: 1px solid #8dbfe2;
+  padding: 0.45em 0.85em;
+  font-size: 0.95em;
+}
+
+.favorites-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+  user-select: none;
+  font-size: 0.85em;
+  cursor: pointer;
+}
+
+.favorites-filter > span {
+  color: #0b2a42;
+}
+
+.bitacora-results {
+  max-height: min(55vh, 31em);
+  overflow-y: auto;
+}
+
+.party-result-item {
+  padding: 0.6em 0.8em;
+  border-bottom: 1px solid #e8eef4;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6em;
+}
+
+.party-result-content {
+  flex: 1;
+}
+
+.party-result-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+}
+
+.party-note-indicator {
+  font-size: 0.75em;
+  line-height: 1;
+  border: 1px solid #8dbfe2;
+  border-radius: 999px;
+  padding: 0.16em 0.2em;
+  background: #fff;
+}
+
+.party-result-item:last-child {
+  border-bottom: none;
+}
+
+.party-result-item:hover {
+  background-color: #edf7ff;
+}
+
+.party-result-title {
+  font-weight: 600;
+}
+
+.party-result-subtitle {
+  font-size: 0.85em;
+  color: #4a6578;
+}
+
+.bitacora-description {
+  margin-bottom: 0.6em;
+}
+
+.favorite-heart-button {
+  border: none;
+  background: transparent;
+  font-size: 1.3em;
+  cursor: pointer;
+  line-height: 1;
+  border-radius: 999px;
+  padding: 0.2em;
+}
+
+.favorite-heart-button:hover {
+  background-color: #ffeef2;
+}
+
+
+.bitacora-mini-calendar {
+  margin-bottom: 0.8em;
+  padding: 0.7em;
+  border: 1px solid #d7e7f3;
+  border-radius: 10px;
+  background: #f7fbff;
+}
+
+.bitacora-mini-calendar-title {
+  font-size: 0.85em;
+  color: #35566f;
+  margin-bottom: 0.5em;
+}
+
+.bitacora-mini-calendar-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35em;
+}
+
+.bitacora-mini-calendar-mode {
+  font-size: 0.8em;
+  color: #3f5f76;
+  margin-bottom: 0.45em;
+}
+
+.mini-day-button {
+  border: 1px solid #8dbfe2;
+  background: white;
+  color: #0b2a42;
+  border-radius: 999px;
+  padding: 0.25em 0.6em;
+  font-size: 0.8em;
+  cursor: pointer;
+  position: relative;
+}
+
+.mini-day-button-commented {
+  padding-left: 1.05em;
+}
+
+.mini-day-comment-badge {
+  position: absolute;
+  top: -0.35em;
+  left: -0.25em;
+  font-size: 0.62em;
+  line-height: 1;
+  background: #fff;
+  border: 1px solid #8dbfe2;
+  border-radius: 999px;
+  padding: 0.16em 0.2em;
+}
+
+.mini-day-button.selected-mini-day {
+  background: #08549c;
+  color: white;
+  border-color: #08549c;
+}
+
+.bitacora-details-head-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.7em;
+  margin-bottom: 0.6em;
+}
+
+.bitacora-details-head {
+  font-size: 1.05em;
+  font-weight: 700;
+  margin-bottom: 0;
+  min-width: 0;
+  flex: 1 1 18em;
+}
+
+.bitacora-details-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  max-width: 100%;
+}
+
+.bitacora-active-penguin {
+  font-size: 0.75em;
+  color: #35566f;
+  background: #eef6ff;
+  border: 1px solid #c8dff2;
+  border-radius: 999px;
+  padding: 0.2em 0.55em;
+  white-space: nowrap;
+}
+
+.bitacora-mode-button {
+
+  border: 1px solid #b8d4e8;
+  background: white;
+  color: #0b2a42;
+  font-size: 0.8em;
+  padding: 0.28em 0.58em;
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  position: relative;
+}
+
+.bitacora-mode-button.active {
+  background: #08549c;
+  color: white;
+  border-color: #08549c;
+}
+
+.bitacora-button-comment-badge {
+  font-size: 0.72em;
+  line-height: 1;
+  border: 1px solid #8dbfe2;
+  border-radius: 999px;
+  padding: 0.15em 0.2em;
+  background: #fff;
+  color: #0b2a42;
+}
+
+.bitacora-mode-button.active .bitacora-button-comment-badge {
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.bitacora-mode-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bitacora-comment-box {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 7.5em;
+  max-height: 32vh;
+  border: 1px solid #8dbfe2;
+  border-radius: 10px;
+  padding: 0.75em;
+  resize: vertical;
+  font-family: inherit;
+  display: block;
+  margin: 0.35em auto 0 auto;
+}
+
+
+.bitacora-status {
+  margin-top: 0.5em;
+  font-size: 0.85em;
+  color: #3f5f76;
 }
 
 body {
@@ -235,4 +514,20 @@ thead th {
 #as3-footer > button {
   padding: 8px;
   transform: scale(1.5);
+}
+
+
+@media (max-width: 1100px) {
+  .bitacora-layout {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .bitacora-results {
+    max-height: 16.5em;
+  }
+
+  .bitacora-comment-box {
+    max-height: 40vh;
+  }
 }

--- a/src/client/views/timeline.html
+++ b/src/client/views/timeline.html
@@ -49,6 +49,8 @@
           <label for="calendar-timeline">Calendar</label>
           <input type="radio" id="list-timeline" name="timeline-type" />
           <label for="list-timeline">List</label>
+          <input type="radio" id="bitacora-timeline" name="timeline-type" />
+          <label for="bitacora-timeline">Logbook</label>
         </div>
       </div>
       <div class="version-selected">

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1242,8 +1242,9 @@ export class Client {
     this.sendXt('jw', seatId);
     this.sendRoomXt('uw', waddleRoom.id, seatId, this.name, this.penguin.id);
     const players = waddleRoom.players;
-    // starts the game if all players have entered
-    if (players.length === waddleRoom.size) {
+    const shouldStartSledSolo = waddleRoom.game === 'sled' && players.length >= 1;
+    // starts the game if all players have entered, or immediately for sled solo play
+    if (players.length === waddleRoom.size || shouldStartSledSolo) {
       const Constructor = this.server.waddleConstructors[waddleRoom.game];
       const waddleGame = new Constructor(players);
       this.server.setWaddleGame(waddleRoom, waddleGame);
@@ -1251,7 +1252,7 @@ export class Client {
       // 2006 sled race notification for starting the game
       if (waddleGame.name === 'sled' && players.every((player) => player.isEngine1)) {
         players.forEach((player) => {
-          player.sendXt('sw', waddleRoom.id, waddleGame.roomId, waddleRoom.size);
+          player.sendXt('sw', waddleRoom.id, waddleGame.roomId, players.length);
         });
         return;
       }

--- a/src/server/database/index.ts
+++ b/src/server/database/index.ts
@@ -4,7 +4,8 @@ import { VERSION } from '../../common/version';
 import { DATABASE_DIRECTORY } from '../../common/paths';
 
 export enum Databases {
-  Penguins = 'penguins'
+  Penguins = 'penguins',
+  TimelineComments = 'timeline-comments'
 }
 
 type JsonProperty = string | number | boolean
@@ -41,6 +42,7 @@ class JsonDatabase {
       if (version !== VERSION) {
         this.migrateDatabase(version);
       }
+      this.createSubDatabase(Databases.TimelineComments);
     } else { // create
       this.createDatabase();
     }
@@ -252,6 +254,7 @@ class JsonDatabase {
       fs.mkdirSync(DATABASE_DIRECTORY)
     }
     db.createSubDatabase(Databases.Penguins, 100);
+    db.createSubDatabase(Databases.TimelineComments);
     fs.writeFileSync(versionFile, VERSION);
   }
 

--- a/src/server/handlers/handles.ts
+++ b/src/server/handlers/handles.ts
@@ -212,7 +212,8 @@ export enum Handle {
   MoveHockeyPuck,
   MoveHockeyPuckOld,
   UpdateHockeyGame,
-  BuyPowerCards
+  BuyPowerCards,
+  WaddleInteractionAck
 };
 
 /** Map of all the handles and their valid arguments */
@@ -408,7 +409,8 @@ export const HANDLE_ARGUMENTS = {
   [Handle.MoveHockeyPuck]: ['number', 'number', 'number', 'number', 'number'],
   [Handle.MoveHockeyPuckOld]: ['number', 'number'],
   [Handle.UpdateHockeyGame]: ['number'],
-  [Handle.BuyPowerCards]: []
+  [Handle.BuyPowerCards]: [],
+  [Handle.WaddleInteractionAck]: 'string'
 } as const;
 
 const HANDLER_MAPPING: HandlerMapping = {
@@ -460,6 +462,9 @@ const HANDLER_MAPPING: HandlerMapping = {
       'ai': Handle.AddItem,
       'qpp': Handle.GetPinInformation,
       'qpa': Handle.GetMissionStamps
+    },
+    'bi': {
+      'ack': Handle.WaddleInteractionAck
     },
     'm': {
       'sm': Handle.HandleSendMessage

--- a/src/server/handlers/play/navigation.ts
+++ b/src/server/handlers/play/navigation.ts
@@ -140,6 +140,11 @@ handler.xt(Handle.CloseBook, (client) => {
   client.sendRoomXt('rt', client.penguin.id);
 });
 
+// Acknowledgement packet sent by some clients when using waddle interactions.
+handler.xt(Handle.WaddleInteractionAck, () => {
+  // no-op: this packet is informational only.
+});
+
 handler.boot(s => {
   s.waddleConstructors = {
     'card': CardJitsu,

--- a/src/server/settings-api.ts
+++ b/src/server/settings-api.ts
@@ -3,6 +3,7 @@ import express, { Express } from 'express';
 import { SettingsManager } from "./settings";
 import { Server } from './client';
 import { Handler } from './handlers';
+import db, { Databases } from './database';
 
 /**
  * Creates the REST API that the client uses to communicate with the server for updating
@@ -10,6 +11,64 @@ import { Handler } from './handlers';
  * @param s Reference to the settings manager consumed by the server
  * @param server
  */
+
+type TimelineCommentsPayload = {
+  dayComments: Record<string, string>;
+  partyComments: Record<string, string>;
+  favoriteParties: string[];
+};
+
+const sanitizeComments = (raw: unknown): Record<string, string> => {
+  if (raw === null || typeof raw !== 'object') {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        result[key] = value;
+      }
+    }
+  }
+
+  return result;
+};
+
+
+const sanitizeFavoriteParties = (raw: unknown): string[] => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw.filter((entry): entry is string => {
+    return typeof entry === 'string' && entry.trim().length > 0;
+  });
+};
+
+const readTimelineComments = (penguinId: number): TimelineCommentsPayload => {
+  const data = db.getById<TimelineCommentsPayload>(Databases.TimelineComments, penguinId);
+  if (data === undefined) {
+    return { dayComments: {}, partyComments: {}, favoriteParties: [] };
+  }
+
+  return {
+    dayComments: sanitizeComments(data.dayComments),
+    partyComments: sanitizeComments(data.partyComments),
+    favoriteParties: sanitizeFavoriteParties(data.favoriteParties)
+  };
+};
+
+const saveTimelineComments = (penguinId: number, body: unknown): void => {
+  const payload = body as Partial<TimelineCommentsPayload>;
+  db.update<TimelineCommentsPayload>(Databases.TimelineComments, penguinId, {
+    dayComments: sanitizeComments(payload.dayComments),
+    partyComments: sanitizeComments(payload.partyComments),
+    favoriteParties: sanitizeFavoriteParties(payload.favoriteParties)
+  });
+};
+
 export const setApiServer = (s: SettingsManager, server: Express, gameServer: Server, gameHandler: Handler): void => {
   const router = express.Router();
 
@@ -49,6 +108,28 @@ export const setApiServer = (s: SettingsManager, server: Express, gameServer: Se
       modsRelation[mod] = activeMods.includes(mod);
     }
     res.json(modsRelation);
+  });
+
+
+  router.get('/timeline-comments/get/:penguinId', (req, res) => {
+    const penguinId = Number(req.params.penguinId);
+    if (!Number.isInteger(penguinId) || penguinId <= 0) {
+      res.status(400).json({ error: 'Invalid penguin id' });
+      return;
+    }
+
+    res.json(readTimelineComments(penguinId));
+  });
+
+  router.post('/timeline-comments/save', (req, res) => {
+    const penguinId = Number(req.body.penguinId);
+    if (!Number.isInteger(penguinId) || penguinId <= 0) {
+      res.status(400).json({ error: 'Invalid penguin id' });
+      return;
+    }
+
+    saveTimelineComments(penguinId, req.body);
+    res.sendStatus(200);
   });
 
   router.get('/players', (_, res) => {


### PR DESCRIPTION
🚀 Update: Parties Logbook in Timeline
You can now switch to “Logbook” from the selector (Calendar / List / Logbook).

What’s included?

🔎 Easier party search (search bar + fast list)

❤️ Favorites: heart a party and filter with “Favorites only”

💬 Notes/Comments: comment indicators + day chips (mini calendar) inside each party

🐧 Linked to your penguin: shows “Logbook owner” at the top and saves everything per account

Full version (announcement style)

📚 New Parties Logbook — Timeline
I added a new Timeline mode: Logbook, next to Calendar and List.

The goal is to make it WAY easier to find parties, save them, and keep “diary-style” notes per user.

✅ Key features

1) Fast party search (no getting lost)
Search bar + list results to quickly find events.

2) Favorites per party
Heart button to save your favorites, plus a “Favorites only” toggle to show only saved ones.

3) Notes/Comments with indicators
💬 Badges to show which parties/days already have notes. Includes a mini calendar (day chips) to jump to the exact day inside a party.

4) Tied to your penguin (remembers the last one)
The logbook links to the active penguin and shows the logbook owner (“Logbook owner”) at the top. It keeps context with the last logged-in penguin, so your favorites/notes stay per account.