### PR TITLE
[bugfix] april fools 2009 box store catalog

### DIFF
--- a/src/server/updates/2009.ts
+++ b/src/server/updates/2009.ts
@@ -811,7 +811,7 @@ export const UPDATES_2009: Update[] = [
         },
         localChanges: {
           'catalogues/party.swf': {
-            'en': 'archives:BoxCatalog.swf'
+            'en': ['archives:BoxCatalog.swf', 'party_catalogue']
           },
           'membership/party3.swf': {
             'en': ['archives:AprilFoolMembership.swf', 'oops_party3_room']


### PR DESCRIPTION
apparently, this wasn't using the right function like the below one. thus the catalog wouldn't be called in the box store.