### PR TITLE
fix: support January 2009 puffle adoption

### DIFF
--- a/src/server/file-generators/local_crumbs.swf.ts
+++ b/src/server/file-generators/local_crumbs.swf.ts
@@ -943,6 +943,198 @@ const getPostcardCrumbs = (): PCodeRep => {
   ].flat();
 }
 
+function getJanuary2009PuffleCompatibility(): number[] {
+  const countFunctionBody = [
+    ...createBytecode([
+      [Action.Push, 0],
+      [Action.Push, "this"],
+      Action.GetVariable,
+      [Action.Push, "getMyPuffleArray"],
+      Action.CallMethod,
+      [Action.Push, "length"],
+      Action.GetMember
+    ]),
+    0x3e // ActionReturn
+  ];
+
+  const addPuffleAlias = (alias: string, legacyName: string): number[] => {
+    const getterBody = [
+      ...createBytecode([
+        [Action.Push, "this"],
+        Action.GetVariable,
+        [Action.Push, legacyName],
+        Action.GetMember
+      ]),
+      0x3e // ActionReturn
+    ];
+
+    return [
+      0x96, 0x01, 0x00, 0x02, // ActionPush null setter
+      0x9b, 0x05, 0x00, // ActionDefineFunction and header length
+      0x00, // anonymous function name
+      0x00, 0x00, // parameter count
+      getterBody.length & 0xff, getterBody.length >> 8,
+      ...getterBody,
+      ...createBytecode([
+        [Action.Push, alias, 3],
+        [Action.Push, "com"],
+        Action.GetVariable,
+        [Action.Push, "clubpenguin"],
+        Action.GetMember,
+        [Action.Push, "shell"],
+        Action.GetMember,
+        [Action.Push, "Puffle"],
+        Action.GetMember,
+        [Action.Push, "prototype"],
+        Action.GetMember,
+        [Action.Push, "addProperty"],
+        Action.CallMethod,
+        Action.Pop
+      ])
+    ];
+  };
+
+  const addPufflesToRoomCall = createBytecode([
+    [Action.Push, 0],
+    [Action.Push, 0],
+    [Action.Push, "_global"],
+    Action.GetVariable,
+    [Action.Push, "getCurrentShell"],
+    Action.CallMethod,
+    [Action.Push, "addPufflesToRoom"],
+    Action.CallMethod,
+    Action.Pop
+  ]);
+
+  const repairPuffleManagerEngine = createBytecode([
+    [Action.Push, 0],
+    [Action.Push, "_global"],
+    Action.GetVariable,
+    [Action.Push, "getCurrentShell"],
+    Action.CallMethod,
+    [Action.Push, "ENGINE"],
+    Action.GetMember,
+    [Action.Push, "puffleManager"],
+    Action.GetMember,
+    [Action.Push, "_engine"],
+    [Action.Push, 0],
+    [Action.Push, "_global"],
+    Action.GetVariable,
+    [Action.Push, "getCurrentShell"],
+    Action.CallMethod,
+    [Action.Push, "ENGINE"],
+    Action.GetMember,
+    Action.SetMember
+  ]);
+
+  const updateListenersFunctionBody = [
+    ...createBytecode([
+      [Action.Push, "result"],
+      [Action.Push, "obj"],
+      Action.GetVariable,
+      [Action.Push, "type"],
+      Action.GetVariable,
+      [Action.Push, 2],
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "_waddleOriginalUpdateListeners"],
+      Action.CallMethod,
+      Action.DefineLocal,
+      [Action.Push, "type"],
+      Action.GetVariable,
+      [Action.Push, "iglooInitComplete"],
+      0x49 as Action, // ActionEquals2
+      0x12 as Action // ActionNot
+    ]),
+    0x9d, 0x02, 0x00, // ActionIf and branch length
+    (repairPuffleManagerEngine.length + addPufflesToRoomCall.length) & 0xff,
+    (repairPuffleManagerEngine.length + addPufflesToRoomCall.length) >> 8,
+    ...repairPuffleManagerEngine,
+    ...addPufflesToRoomCall,
+    ...createBytecode([
+      [Action.Push, "result"],
+      Action.GetVariable
+    ]),
+    0x3e // ActionReturn
+  ];
+
+  return [
+    ...createBytecode([
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "getMyPuffleCount"]
+    ]),
+    0x9b, 0x05, 0x00, // ActionDefineFunction and header length
+    0x00, // anonymous function name
+    0x00, 0x00, // parameter count
+    countFunctionBody.length & 0xff, countFunctionBody.length >> 8,
+    ...countFunctionBody,
+    Action.SetMember,
+    ...createBytecode([
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "getMyPuffleById"],
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "getPuffleObjectById"],
+      Action.GetMember,
+      Action.SetMember
+    ]),
+    ...addPuffleAlias("id", "puffle_id"),
+    ...addPuffleAlias("typeID", "type_id"),
+    ...addPuffleAlias("isWalking", "is_walking"),
+    ...createBytecode([
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "IGLOO_INIT_COMPLETE", "iglooInitComplete"],
+      Action.SetMember,
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "_waddleOriginalUpdateListeners"],
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "updateListeners"],
+      Action.GetMember,
+      Action.SetMember,
+      [Action.Push, 0],
+      [Action.Push, "_global"],
+      Action.GetVariable,
+      [Action.Push, "getCurrentShell"],
+      Action.CallMethod,
+      [Action.Push, "updateListeners"]
+    ]),
+    0x9b, 0x0e, 0x00, // ActionDefineFunction and header length
+    0x00, // anonymous function name
+    0x02, 0x00, // parameter count
+    0x74, 0x79, 0x70, 0x65, 0x00, // type
+    0x6f, 0x62, 0x6a, 0x00, // obj
+    updateListenersFunctionBody.length & 0xff, updateListenersFunctionBody.length >> 8,
+    ...updateListenersFunctionBody,
+    Action.SetMember
+  ];
+}
+
 export function getLocalCrumbsSwf(d: GameData): Buffer {
   // hardcoded hex dump of the function's bytecode
   const treverseMessages = [
@@ -1971,7 +2163,13 @@ export function getLocalCrumbsSwf(d: GameData): Buffer {
     ...getHuntCrumbs(d.getHunt())
   ];
 
-  const bytecode = [...treverseMessages, ...createBytecode(code)];
+  const shellFile = d.lookupFile('play/v2/shell/shell.swf');
+  const puffleCompatibility = typeof shellFile === 'string'
+    && shellFile.endsWith('ClientShell_January_2009.swf')
+    ? getJanuary2009PuffleCompatibility()
+    : [];
+
+  const bytecode = [...treverseMessages, ...puffleCompatibility, ...createBytecode(code)];
 
   return Buffer.from(emitCrumbSwf(new Uint8Array(bytecode)));
 }

--- a/src/server/game-data/cpip-static.ts
+++ b/src/server/game-data/cpip-static.ts
@@ -488,7 +488,7 @@ export const CPIP_STATIC_FILES: RouteRefMap = {
   'play/v2/content/local/en/postcards/108.swf': 'archives:ENPostcards108.swf',
   'play/v2/content/local/en/postcards/109.swf': 'archives:ENPostcards109.swf',
   'play/v2/content/local/en/postcards/110.swf': 'archives:ENPostcards110.swf',
-  'play/v2/content/local/en/postcards/111.swf': 'archives:ENPostcards111.swf',
+  'play/v2/content/local/en/postcards/111.swf': 'archives:Enm111.swf',
   'play/v2/content/local/en/postcards/112.swf': 'archives:ENPostcards112.swf',
   'play/v2/content/local/en/postcards/120.swf': 'archives:ENPostcards120.swf',
   'play/v2/content/local/en/postcards/121.swf': 'archives:ENPostcards121.swf',

--- a/src/server/socket-server/handlers/puffle.ts
+++ b/src/server/socket-server/handlers/puffle.ts
@@ -165,6 +165,10 @@ function getPuffleString(puffle: PlayerPuffle): string {
   ].join('|')
 }
 
+export const handleGetMyPufflesOld: PenguinHandler<[]> = ({ msg, penguin }) => {
+  msg.send(penguin, 'pgu', ...penguin.puffle.puffles.map(getPuffleString));
+}
+
 export const sendModernPuffleCheck: PenguinHandler<[string]> = ({ msg, penguin }, name) => {
   msg.send(penguin, 'checkpufflename', name, 1);
 }
@@ -548,7 +552,7 @@ export const handleRevealGoldPuffle: PenguinHandler<[]> = ({ msg, penguin }) => 
   msg.send(penguin, 'revealgoldpuffle', penguin.id);
 }
 
-export const handleGetIglooPufflesOld: PenguinHandler<[number]> = (ctx, id) => {
+export const handleGetIglooPufflesOld: PenguinHandler<number[]> = (ctx, id = 0) => {
   handleGetIglooPuffles(ctx, id, '');
 }
 
@@ -565,7 +569,7 @@ export const handleGetIglooPuffles: PenguinHandler<[number, string]> = ({ data, 
         100,
         100,
         100,
-        0,
+        Math.round((puffle.clean + puffle.food + puffle.rest) / 3),
         0,
         0,
         puffle.id === penguin.puffle.walking ? 1 : 0

--- a/src/server/socket-server/world-handlers.ts
+++ b/src/server/socket-server/world-handlers.ts
@@ -10,7 +10,7 @@ import { handleLeaveGame, handleRoomRefresh, isGameGuard } from "./handlers/game
 import { getIglooOld, handleAddFlooring, handleAddFurniture, handleAddIgloo, handleAddIglooLayout, handleAddIglooLocation, handleCloseIgloo, handleGetAllIglooLayouts, handleGetDj3kTracks, handleGetFurniture, handleGetFurnitureNew, handleGetIglooCpip, handleGetIglooItems, handleGetIglooLikes, handleGetIglooTypes, handleGetMusicTracks, handleGetOpenIgloos, handleOpenIgloo, handleUpdateIgloo, handleUpdateIglooLayout, handleUpdateIglooNew, handleUpdateIglooOld, handleUpdateIglooType, handleUpdateMusic } from "./handlers/igloo";
 import { handleBuyNinjaCards, handleGetFireLevel, handleGetNinjaCards, handleGetNinjaLevel, handleGetNinjaRanks, handleGetWaterLevel, handleJoinFromMatchmake, handleJoinMatchmaking, handleJoinSensei, handleLeaveMatchmake } from "./handlers/ninja";
 import { handleDonateCoins, handleGetBakeryState, handleGetCookieInventory, handleRetrieveMedieval2012, handleSendEnterHopper, handleViewedMedieval2012 } from "./handlers/party";
-import { handleAdoptPuffle, handleAdoptPuffleOld, handleEatPuffleItem, handleGetIglooPuffles, handleGetIglooPufflesOld, handleGetPuffleInventory, handlePuffleBackyardSwap, handlePuffleDigOnCommand, handlePuffleDigRandom, handlePuffleWalk, handleRevealGoldPuffle, isAfterPuffleCreatureGuard, isBeforePuffleCreatureGuard, sendModernPuffleCheck, sendPuffleCheck } from "./handlers/puffle";
+import { handleAdoptPuffle, handleAdoptPuffleOld, handleEatPuffleItem, handleGetIglooPuffles, handleGetIglooPufflesOld, handleGetMyPufflesOld, handleGetPuffleInventory, handlePuffleBackyardSwap, handlePuffleDigOnCommand, handlePuffleDigRandom, handlePuffleWalk, handleRevealGoldPuffle, isAfterPuffleCreatureGuard, isBeforePuffleCreatureGuard, sendModernPuffleCheck, sendPuffleCheck } from "./handlers/puffle";
 import { handleGetRainbowQuestData, handleSendRainbowQuestBonusCoins, handleSendRainbowQuestCollectCoins, handleSendRainbowQuestItemCollect, handleSendRainbowTaskComplete } from "./handlers/rainbow";
 import { handleEndSled, handleJoinSled, handleMoveSled, isSledGuard } from "./handlers/sled";
 import { BaseContext, GuardFunction, HandlerFunction, WorldContext } from "@server/socket-server/handlers/handlers";
@@ -227,8 +227,9 @@ export const createWorldXtHandler = (): XtHandler => {
     r.xt('s', 's#upl', ['number'], handleUpdatePin),
     r.xt('s', 's#upp', ['number'], handleUpdateBackground),
     
-    p.xt('s', 'p#pg', ['number'], handleGetIglooPufflesOld, { guard: isPreBackyardGuard }),
+    p.xt('s', 'p#pg', 'number', handleGetIglooPufflesOld, { guard: isPreBackyardGuard }),
     p.xt('s', 'p#pg', ['number', 'string'], handleGetIglooPuffles, { guard: isBackyardGuard }),
+    p.xt('s', 'p#pgu', [], handleGetMyPufflesOld, { guard: isBeforePuffleCreatureGuard }),
     p.xt('s', 'p#pn', ['number', 'string'], handleAdoptPuffleOld, { guard: isBeforePuffleCreatureGuard }),
     p.xt('s', 'p#pn', ['number', 'string', 'number'], handleAdoptPuffle, { guard: isAfterPuffleCreatureGuard, xt: { cooldown: 2000 }}),
     p.xt('s', 'p#pgpi', [], handleGetPuffleInventory),


### PR DESCRIPTION
The fix adds January 2009 puffle-adoption compatibility by:

- Injecting legacy shell aliases and igloo/puffle initialization behavior.
- Supporting legacy pgu and optional-argument pg packets.
- Returning the expected puffle health value.
- Correcting adoption postcard 111’s asset path.


