### PR TITLE
Fix multiplayer puffle synchronization

### DIFF
--- a/src/server/socket-server/handlers/join.ts
+++ b/src/server/socket-server/handlers/join.ts
@@ -103,20 +103,24 @@ const enterRoom: PenguinHandler<[WorldRoom, number, number]> = (ctx, r, x, y) =>
   msg.send(penguin, 'jr', r.id, ...r.playerStates.map(([p, s]) => getPenguinString(data, p, s)));
   msg.send(r.players, 'ap', getPenguinString(data, penguin, { x, y, frame: 1 }));
 
-  const replayWalkingPuffle = (player: WorldPenguin, recipients: WorldPenguin | WorldPenguin[]) => {
-    const walkingPuffleId = player.puffle.walking;
-    if (walkingPuffleId === null) {
-      return;
-    }
 
-    const args = getPuffleWalkArguments(data, player, walkingPuffleId, 1);
-    if (args !== undefined) {
-      msg.send(recipients, 'pw', ...args);
-    }
-  };
-
-  previousPlayers.forEach((player) => replayWalkingPuffle(player, penguin));
-  replayWalkingPuffle(penguin, previousPlayers);
+  // modern versions don't have the puffle information on penguin so the packet is resent
+  if (!data.puffleHandItems()) {
+    const replayWalkingPuffle = (player: WorldPenguin, recipients: WorldPenguin | WorldPenguin[]) => {
+      const walkingPuffleId = player.puffle.walking;
+      if (walkingPuffleId === null) {
+        return;
+      }
+  
+      const args = getPuffleWalkArguments(data, player, walkingPuffleId, 1);
+      if (args !== undefined) {
+        msg.send(recipients, 'pw', ...args);
+      }
+    };
+  
+    previousPlayers.forEach((player) => replayWalkingPuffle(player, penguin));
+    replayWalkingPuffle(penguin, previousPlayers);
+  }
 }
 
 export function filterItems(data: GameData, items: number[]): number[] {

--- a/src/server/socket-server/handlers/join.ts
+++ b/src/server/socket-server/handlers/join.ts
@@ -5,7 +5,7 @@ import { WorldPenguin } from '@server/socket-server/world/world-penguin';
 import { WorldRoom } from '@server/socket-server/world/world-room';
 import { GameData } from '@server/timelines/game-data';
 import { PenguinMessenger } from '../../socket-server/messenger';
-import { getClientPuffleIds } from './puffle';
+import { getClientPuffleIds, getPuffleWalkArguments } from './puffle';
 import { getFurnitureString, getIglooFromId } from './igloo';
 import { WorldTable } from '@server/socket-server/world/world-table';
 import { getOfflinePenguinCrumb } from '@server/http/php-server';
@@ -97,10 +97,26 @@ export function getPenguinString(data: GameData, p: WorldPenguin, state: { x: nu
 
 const enterRoom: PenguinHandler<[WorldRoom, number, number]> = (ctx, r, x, y) => {
   const { penguin, msg, data, world } = ctx;
+  const previousPlayers = r.players;
   r.addPenguin(penguin, x, y);
   world.enterState(penguin, { room: r });
   msg.send(penguin, 'jr', r.id, ...r.playerStates.map(([p, s]) => getPenguinString(data, p, s)));
   msg.send(r.players, 'ap', getPenguinString(data, penguin, { x, y, frame: 1 }));
+
+  const replayWalkingPuffle = (player: WorldPenguin, recipients: WorldPenguin | WorldPenguin[]) => {
+    const walkingPuffleId = player.puffle.walking;
+    if (walkingPuffleId === null) {
+      return;
+    }
+
+    const args = getPuffleWalkArguments(data, player, walkingPuffleId, 1);
+    if (args !== undefined) {
+      msg.send(recipients, 'pw', ...args);
+    }
+  };
+
+  previousPlayers.forEach((player) => replayWalkingPuffle(player, penguin));
+  replayWalkingPuffle(penguin, previousPlayers);
 }
 
 export function filterItems(data: GameData, items: number[]): number[] {

--- a/src/server/socket-server/handlers/puffle.ts
+++ b/src/server/socket-server/handlers/puffle.ts
@@ -261,6 +261,20 @@ export const handleGetPuffleInventory: PenguinHandler<[]> = ({ msg, penguin }) =
   );
 }
 
+export function getPuffleWalkArguments(data: GameData, penguin: WorldPenguin, penguinPuffleId: number, walking: number): Array<string | number> | undefined {
+  if (data.isVanillaEngine()) {
+    const playerPuffle = penguin.puffle.getPuffle(penguinPuffleId);
+    if (playerPuffle === undefined) {
+      return undefined;
+    }
+
+    // TODO hat (last one)
+    return [penguin.id, playerPuffle.id, ...getClientPuffleIds(playerPuffle.type), walking, 0];
+  }
+
+  return [penguin.id, `${penguinPuffleId}||||||||||||${walking}`];
+}
+
 export const handlePuffleWalk: PenguinHandler<[number, number]> = (ctx, penguinPuffleId, walking) => {
   // TODO add puffle refusing to walk
   // TODO add removing puffle
@@ -274,14 +288,9 @@ export const handlePuffleWalk: PenguinHandler<[number, number]> = (ctx, penguinP
 
   const penguins = 'room' in ctx ? ctx.room.players : [penguin];
 
-  if (data.isVanillaEngine()) {
-    const playerPuffle = penguin.puffle.getPuffle(penguinPuffleId);
-    if (playerPuffle !== undefined) {
-      // TODO hat (last one)
-      msg.send(penguin, 'pw', penguin.id, playerPuffle.id, ...getClientPuffleIds(playerPuffle.type), walking, 0);
-    }
-  } else {
-    msg.send(penguins, 'pw', penguin.id, `${penguinPuffleId}||||||||||||${walking}`);
+  const args = getPuffleWalkArguments(data, penguin, penguinPuffleId, walking);
+  if (args !== undefined) {
+    msg.send(penguins, 'pw', ...args);
   }
   prst(penguin);
 }
@@ -305,13 +314,14 @@ enum TreasureType {
   Gold = 4
 };
 
-const sendPuffleDig: PenguinHandler<[TreasureType, number]> = ({ msg, penguin }, treasureType, target) => {
+const sendPuffleDig: PenguinHandler<[TreasureType, number]> = (ctx, treasureType, target) => {
+  const { msg, penguin } = ctx;
   const [coins, itemId] =
     treasureType === TreasureType.Coins ? [target, 0] :
     treasureType === TreasureType.Gold ? [target, 1] : [0, target];
 
-  // TODO multiplayer logic so it sneds to everyone in room
-  msg.send(penguin, 'puffledig', penguin.id, penguin.puffle.walking ?? 0, treasureType, itemId, coins, penguin.dig.hasDug ? 0 : 1);
+  const penguins = 'room' in ctx ? ctx.room.players : [penguin];
+  msg.send(penguins, 'puffledig', penguin.id, penguin.puffle.walking ?? 0, treasureType, itemId, coins, penguin.dig.hasDug ? 0 : 1);
 }
 
 const sendGoldNuggets: PenguinHandler<[]> = ({ msg, penguin }) => {
@@ -614,5 +624,5 @@ export const isBeforePuffleCreatureGuard: PenguinGuard = (ctx) => {
   return !isAfterPuffleCreatureGuard(ctx);
 }
 
-export const handlePuffleDigRandom: PenguinHandler<[]> = (ctx) => puffleDig(ctx, false);
+export const handlePuffleDigRandom: PenguinHandler<[number]> = (ctx) => puffleDig(ctx, false);
 export const handlePuffleDigOnCommand: PenguinHandler<[]> = (ctx) => puffleDig(ctx, true);

--- a/src/server/socket-server/handlers/puffle.ts
+++ b/src/server/socket-server/handlers/puffle.ts
@@ -5,7 +5,7 @@ import { PUFFLES } from "@server/game-logic/puffle";
 import { PlayerPuffle } from "@server/database/database";
 import { choose, randomInt } from "@common/utils";
 import { PUFFLE_ITEMS } from "@server/game-logic/puffle-item";
-import { PenguinHandler, PenguinGuard } from "./handlers";
+import { PenguinHandler, PenguinGuard, RoomHandler } from "./handlers";
 import { handleReceiveMail } from "./mail";
 
 
@@ -314,14 +314,13 @@ enum TreasureType {
   Gold = 4
 };
 
-const sendPuffleDig: PenguinHandler<[TreasureType, number]> = (ctx, treasureType, target) => {
-  const { msg, penguin } = ctx;
+const sendPuffleDig: RoomHandler<[TreasureType, number]> = (ctx, treasureType, target) => {
+  const { msg, penguin, room } = ctx;
   const [coins, itemId] =
     treasureType === TreasureType.Coins ? [target, 0] :
     treasureType === TreasureType.Gold ? [target, 1] : [0, target];
 
-  const penguins = 'room' in ctx ? ctx.room.players : [penguin];
-  msg.send(penguins, 'puffledig', penguin.id, penguin.puffle.walking ?? 0, treasureType, itemId, coins, penguin.dig.hasDug ? 0 : 1);
+  msg.send(room.players, 'puffledig', penguin.id, penguin.puffle.walking ?? 0, treasureType, itemId, coins, penguin.dig.hasDug ? 0 : 1);
 }
 
 const sendGoldNuggets: PenguinHandler<[]> = ({ msg, penguin }) => {
@@ -329,7 +328,7 @@ const sendGoldNuggets: PenguinHandler<[]> = ({ msg, penguin }) => {
   msg.send(penguin, 'currencies', `1|${penguin.gold.nuggets}`);
 }
 
-const puffleDig: PenguinHandler<[boolean]> = (ctx, onCommand: boolean) => {
+const puffleDig: RoomHandler<[boolean]> = (ctx, onCommand: boolean) => {
   const { msg, penguin, data, prst } = ctx;
   // PUFFLE DIG MECHANICS
   // Puffle digging is a completely server-side feature and with a big amount of variables,
@@ -624,5 +623,5 @@ export const isBeforePuffleCreatureGuard: PenguinGuard = (ctx) => {
   return !isAfterPuffleCreatureGuard(ctx);
 }
 
-export const handlePuffleDigRandom: PenguinHandler<[number]> = (ctx) => puffleDig(ctx, false);
-export const handlePuffleDigOnCommand: PenguinHandler<[]> = (ctx) => puffleDig(ctx, true);
+export const handlePuffleDigRandom: RoomHandler<[]> = (ctx) => puffleDig(ctx, false);
+export const handlePuffleDigOnCommand: RoomHandler<[]> = (ctx) => puffleDig(ctx, true);

--- a/src/server/socket-server/world-handlers.ts
+++ b/src/server/socket-server/world-handlers.ts
@@ -236,7 +236,7 @@ export const createWorldXtHandler = (): XtHandler => {
     p.xt('s', 'p#pcn', ['string'], sendPuffleCheck),
     p.xt('s', 'p#pw', ['number', 'number'], handlePuffleWalk),
     p.xt('s', 'p#puffleswap', ['number', 'string'], handlePuffleBackyardSwap),
-    p.xt('s', 'p#puffledig', [], handlePuffleDigRandom),
+    p.xt('s', 'p#puffledig', ['number'], handlePuffleDigRandom),
     p.xt('s', 'p#puffledigoncommand', [], handlePuffleDigOnCommand),
     p.xt('s', 'p#pcid', ['number', 'number'], handleEatPuffleItem),
     p.xt('s', 'p#revealgoldpuffle', [], handleRevealGoldPuffle),

--- a/src/server/socket-server/world-handlers.ts
+++ b/src/server/socket-server/world-handlers.ts
@@ -236,8 +236,8 @@ export const createWorldXtHandler = (): XtHandler => {
     p.xt('s', 'p#pcn', ['string'], sendPuffleCheck),
     p.xt('s', 'p#pw', ['number', 'number'], handlePuffleWalk),
     p.xt('s', 'p#puffleswap', ['number', 'string'], handlePuffleBackyardSwap),
-    p.xt('s', 'p#puffledig', ['number'], handlePuffleDigRandom),
-    p.xt('s', 'p#puffledigoncommand', [], handlePuffleDigOnCommand),
+    r.xt('s', 'p#puffledig', ['number'], handlePuffleDigRandom),
+    r.xt('s', 'p#puffledigoncommand', [], handlePuffleDigOnCommand),
     p.xt('s', 'p#pcid', ['number', 'number'], handleEatPuffleItem),
     p.xt('s', 'p#revealgoldpuffle', [], handleRevealGoldPuffle),
 

--- a/src/server/timelines/game-data.ts
+++ b/src/server/timelines/game-data.ts
@@ -104,6 +104,7 @@ type GameState = {
   extraWaddleRooms: WaddleRoomInfo[];
   iglooMusicReleased: boolean;
   ownedIgloos: boolean;
+  puffleHandItems: boolean;
 }
 
 function getFreshState(): GameState {
@@ -157,7 +158,8 @@ function getFreshState(): GameState {
     releasedStamps: new Set<number>(),
     extraWaddleRooms: [],
     iglooMusicReleased: false,
-    ownedIgloos: false
+    ownedIgloos: false,
+    puffleHandItems: true
   };
 }
 
@@ -298,6 +300,8 @@ export class GameData {
             break;
           case 'vanilla-engine':
             this.state.vanillaEngine = true;
+            // intersection until the 2012 PR is added
+            this.state.puffleHandItems = false;
             this.addRouteMap(AS3_STATIC_FILES);
             break;
           case 'as3':
@@ -971,5 +975,9 @@ export class GameData {
 
   public isAfterOwnedIgloos() {
     return this.state.ownedIgloos;
+  }
+
+  public puffleHandItems() {
+    return this.state.puffleHandItems;
   }
 }


### PR DESCRIPTION
- Broadcast puffle walk/unwalk updates to everyone in the room.
- Replay walking puffles when players enter a room.
- Broadcast puffle-dig animations and rewards to everyone in the room.
- Accept the player ID sent with random-dig requests.