### PR TITLE
Fix create mod popup not being fixed when scrolling

### DIFF
--- a/src/client/views/base.css
+++ b/src/client/views/base.css
@@ -73,7 +73,7 @@ input[type="number"] {
   margin: 0;
   width: 100vw;
   height: 100vh;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   display: flex;


### PR DESCRIPTION
this would happen if you had so many mods that you could scroll the window, but the popup would always stay at the top of the page